### PR TITLE
Fix the readability of some elements

### DIFF
--- a/gnome-shell/components/_dialog.scss
+++ b/gnome-shell/components/_dialog.scss
@@ -3,7 +3,7 @@
        color: black;
 
 }
-.modal-dialog .modal-dialog-linked-button, .notification-button {
+.modal-dialog .modal-dialog-linked-button, .notification-button, .modal-dialog-button {
    /* background-color: black; */
        color: black;
 

--- a/gnome-shell/components/_icongrid.scss
+++ b/gnome-shell/components/_icongrid.scss
@@ -1,6 +1,0 @@
-/*
-ICON GRID
- */
-.overview-icon-with-label{
-  color: $dark;
-}

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -251,13 +251,6 @@ overview is the view you get when clicking on "Activities" or hitting mod4
 }
 
 /*
-ICON GRID
- */
-.overview-icon-with-label {
-  color: #000000;
-}
-
-/*
 BUTTONS
  */
 #LookingGlassDialog > #Toolbar .lg-toolbar-button, .app-folder-dialog .folder-name-container .edit-folder-button, .button, .icon-button {
@@ -381,7 +374,7 @@ QUICKSETTINGS
   color: black;
 }
 
-.modal-dialog .modal-dialog-linked-button, .notification-button {
+.modal-dialog .modal-dialog-linked-button, .notification-button, .modal-dialog-button {
   /* background-color: black; */
   color: black;
 }

--- a/gnome-shell/gnome-shell.scss
+++ b/gnome-shell/gnome-shell.scss
@@ -6,7 +6,6 @@
 @import "components/dash";
 @import "components/keyboard";
 @import "components/overview";
-@import "components/icongrid";
 @import "components/buttons";
 @import "components/osdwindow";
 @import "components/modaldialog";


### PR DESCRIPTION
Fixed the readability of the app labels in the apps scroll view
The style in components/_icongrid.scss seemd to be the culprit. Removed the file and its reference
Before: 
![image](https://github.com/user-attachments/assets/d8d2d921-87c7-4c7e-b554-8734082e3be3)
After:
![image](https://github.com/user-attachments/assets/d959f940-478e-42da-8921-419cb493d72c)

The modal buttons e.g. for authentication.
Before: (blue border was from selection, that did not change)
![image](https://github.com/user-attachments/assets/be20b9f1-ca78-4951-ad27-441884226ac3)
After:
![image](https://github.com/user-attachments/assets/7b0e4705-2ff7-419c-b3d1-b56fed67c118)
